### PR TITLE
Tighten up the host dirs mappings

### DIFF
--- a/collector/templates/probe.yaml
+++ b/collector/templates/probe.yaml
@@ -34,17 +34,23 @@ spec:
         securityContext:
           {{- toYaml .Values.probes.securityContext | nindent 10 }}
         volumeMounts:
-        - name: host-root
-          mountPath: /host
+        - name: host-run
+          mountPath: /host/run
+          readOnly: true
+        - name: host-var
+          mountPath: /host/var
+          readOnly: true
+        - name: host-etc
+          mountPath: /host/etc
+          readOnly: true
+        - name: tracefs
+          mountPath: /sys/kernel/tracing
           readOnly: true
         - mountPath: /etc/nats-certs/nats
           name: nats-tls
           readOnly: true
         - mountPath: /etc/nats-ca-cert
           name: tls-ca
-          readOnly: true
-        - name: sys
-          mountPath: /sys
           readOnly: true
         - name: logmeta
           mountPath: /etc/prequel/logmeta
@@ -89,14 +95,22 @@ spec:
       {{- end }}
       serviceAccountName: {{ include "probes.serviceAccountName" . }}
       volumes:
-      - name: host-root
+      - name: host-run
         hostPath:
-            path: /
-            type: Directory
-      - name: sys
+          path: /run
+          type: Directory
+      - name: host-etc
         hostPath:
-            path: /sys
-            type: Directory
+          path: /etc
+          type: Directory
+      - name: host-var
+        hostPath:
+          path: /var
+          type: Directory
+      - name: tracefs
+        hostPath:
+          path: /sys/kernel/tracing
+          type: Directory
       - name: nats-tls
         secret:
           secretName: nats-tls


### PR DESCRIPTION
This seems to be working, deployed on dev cluster now.

Looking through the code the following host dirs needed to be exposed:
```
	pathPersistentJournal = "/var/log/journal"
	pathVolatileJournal   = "/run/log/journal"
	pathMachineId         = "/etc/machine-id"
```

```
var wellKnownEndpoints = []string{
	"unix:///run/containerd/containerd.sock",
	"unix:///run/cri-dockerd.sock", // minkiube has crio.sock on control plane node that doesn't respond properly to getContainer
	"unix:///run/crio/crio.sock",
}  
```

```
/var/log/journal
/run/log/journal   
```

These can have prefix applied (so mapping /etc for now too)
```
/etc/prequel/spool 
/etc/machine-id 
```

Looks like the prefix `/host` can be applied on these code paths.


Based on these findings mapped the following host directories:
```
/host/run
/host/etc
/host/var  
```

Also tightened up the `/sys` to `/sys/kernel/tracing`, that all we need for now for eBPF tracepoint as far as I understand.

Let me know if we need to tighten them up even further or if I missed anything.