### PR TITLE
Add perms for metrics; little extra time to shutdown TSDB.

### DIFF
--- a/collector/templates/collector.yaml
+++ b/collector/templates/collector.yaml
@@ -27,6 +27,7 @@ spec:
       serviceAccountName: {{ include "collector.serviceAccountName" . }}
       securityContext:
         fsGroup: {{ .Values.collector.securityContext.fsGroup }}
+      terminationGracePeriodSeconds: 60 # Provide extra time for TSDB graceful shutdown
       volumes:
         - name: nats-tls
           secret:
@@ -288,6 +289,8 @@ metadata:
   name: {{ include "collector.fullname" . }}
   namespace: {{ .Release.Namespace }}
 rules:
+- nonResourceURLs: ["/metrics"] # for kube-state-metrics scraping
+  verbs: ["get"]
 - apiGroups:
   - apps 
   resources:
@@ -318,6 +321,10 @@ rules:
   - secrets
   - endpoints
   - configmaps
+  # for kube-state-metrics scraping
+  - nodes/metrics
+  - nodes/proxy
+  - services/proxy
   verbs:
   - list
   - watch


### PR DESCRIPTION
Made grace period 60s.  I saw it stall a couple times, but not since I made the WAL compressed.   Could still happen though.

If a new collector starts while the old TSDB is locked, it will fail and back off.
