### PR TITLE
Pass TDSB size into the collector as an environment variable.

### DIFF
--- a/collector/templates/collector.yaml
+++ b/collector/templates/collector.yaml
@@ -128,6 +128,8 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: spec.nodeName
+          - name: TSDB_MAX_SIZE
+            value: {{ .Values.collector.tsdb.tsdbSize }}
           volumeMounts:
           - mountPath: /etc/nats-certs/nats
             name: nats-tls


### PR DESCRIPTION
Used to limit the size of the database to avoid running out of disk space. May be set to zero to disable the feature.