### PR TITLE
Set option 'collector.tsdb.enabled' to prevent to avoid PVC from bein…

### DIFF
--- a/collector/templates/collector.yaml
+++ b/collector/templates/collector.yaml
@@ -41,9 +41,11 @@ spec:
         - name: k8s-spool-volume
           persistentVolumeClaim:
             claimName: k8s-spool-pv-claim
+{{- if .Values.collector.tsdb.enabled }}
         - name: tsdb-volume
           persistentVolumeClaim:
             claimName: tsdb-pv-claim
+{{- end }}
         - name: spool-volume
           persistentVolumeClaim:
             claimName: spool-pv-claim
@@ -84,8 +86,10 @@ spec:
             mountPath: /etc/prequel/spool_legacy/k8s
           - name: cache-volume
             mountPath: /etc/prequel-policy
+{{- if .Values.collector.tsdb.enabled }}
           - name: tsdb-volume
             mountPath: "/etc/prequel/tsdb/"
+{{- end }}
         - name: "cgroupid"
           image: "busybox@sha256:2f590fc602ce325cbff2ccfc39499014d039546dc400ef8bbf5c6ffb860632e7"
           imagePullPolicy: IfNotPresent
@@ -128,6 +132,8 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: spec.nodeName
+          - name: TSDB_ENABLED
+            value: {{ .Values.collector.tsdb.enabled | quote }}
           - name: TSDB_MAX_SIZE
             value: {{ .Values.collector.tsdb.tsdbSize }}
           volumeMounts:
@@ -145,8 +151,10 @@ spec:
             name: spool-volume
           - name: shared-data
             mountPath: /data
+{{- if .Values.collector.tsdb.enabled }}
           - mountPath: "/etc/prequel/tsdb/"
             name: tsdb-volume
+{{- end }}
           ports:
           - name: health
             containerPort: 8081
@@ -216,6 +224,7 @@ spec:
     requests:
       storage: {{ .Values.collector.k8s.eventSpoolSize }}
 ---
+{{- if .Values.collector.tsdb.enabled }}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
@@ -227,6 +236,7 @@ spec:
   resources:
     requests:
       storage: {{ .Values.collector.tsdb.tsdbSize }}
+{{- end }}
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim

--- a/collector/values.yaml
+++ b/collector/values.yaml
@@ -86,6 +86,7 @@ collector:
   # The event spool size for Prequel events.
   tsdb:
     tsdbSize: 5Gi
+    enabled: true # enabled tsdb volume
   eventSpool:
     size: 128Mi
   # The Prequel collector image.


### PR DESCRIPTION
…g created or mounted.

Customers who do not want the overhead can use this to disable the feature.

Note: Setting tsdb.size to 0 does not disable the feature; the template rejects the type. Previous commit comment was incorrect.