### PR TITLE
Add /sys/kernel/debug to the mounts

### DIFF
--- a/collector/templates/probe.yaml
+++ b/collector/templates/probe.yaml
@@ -43,11 +43,8 @@ spec:
         - name: host-etc
           mountPath: /host/etc
           readOnly: true
-        - name: tracefs
-          mountPath: /sys/kernel/tracing
-          readOnly: true
-        - name: debugfs
-          mountPath: /sys/kernel/debug
+        - name: sys-kernel
+          mountPath: /sys/kernel
           readOnly: true
         - mountPath: /etc/nats-certs/nats
           name: nats-tls
@@ -110,13 +107,9 @@ spec:
         hostPath:
           path: /var
           type: Directory
-      - name: tracefs
+      - name: sys-kernel
         hostPath:
-          path: /sys/kernel/tracing
-          type: Directory
-      - name: debugfs
-        hostPath:
-          path: /sys/kernel/debug
+          path: /sys/kernel
           type: Directory
       - name: nats-tls
         secret:

--- a/collector/templates/probe.yaml
+++ b/collector/templates/probe.yaml
@@ -46,6 +46,9 @@ spec:
         - name: tracefs
           mountPath: /sys/kernel/tracing
           readOnly: true
+        - name: debugfs
+          mountPath: /sys/kernel/debug
+          readOnly: true
         - mountPath: /etc/nats-certs/nats
           name: nats-tls
           readOnly: true
@@ -110,6 +113,10 @@ spec:
       - name: tracefs
         hostPath:
           path: /sys/kernel/tracing
+          type: Directory
+      - name: debugfs
+        hostPath:
+          path: /sys/kernel/debug
           type: Directory
       - name: nats-tls
         secret:


### PR DESCRIPTION
Adds `/sys/kernel/debug` mount. Without this our probes are failing attaching tracepoints on our production cluster
with the error: ```neither debugfs nor tracefs are mounted```


```
Modern kernels expose tracepoints via tracefs
→ usually mounted at /sys/kernel/tracing

Older setups (or fallback) use debugfs
→ usually mounted at /sys/kernel/debug
```

Hopefully the `/sys/kernel/debug` is there. According to the documentation it's not guaranteed, but seems to be available at least on our clusters.

The more flexible option would need us to mount `/sys/kernel`, that would work for all kernels.

