### PR TITLE
Separate TSDB write ahead log (wal) storage from block storage to imp…

### DIFF
--- a/collector/templates/collector.yaml
+++ b/collector/templates/collector.yaml
@@ -45,6 +45,9 @@ spec:
         - name: tsdb-volume
           persistentVolumeClaim:
             claimName: tsdb-pv-claim
+        - name: tsdb-wal-volume
+          persistentVolumeClaim:
+            claimName: tsdb-wal-pv-claim
 {{- end }}
         - name: spool-volume
           persistentVolumeClaim:
@@ -72,13 +75,22 @@ spec:
                 echo "⚠️  Path not found: $p"
               fi
             done
+
+            # Initial implementation of TSDB did not mount wal separately, so clean it up here.
+            DIR="/etc/prequel/tsdb/wal"
+            if [ -d "$DIR" ]; then
+                rm -rf "$DIR"
+                echo "Removed directory: $DIR"
+            else
+                echo "Directory does not exist: $DIR"
+            fi
           env:
           - name: "FIX_UID"
             value: "{{ .Values.collector.securityContext.runAsUser }}"
           - name: "FIX_GID"
             value: "{{ .Values.collector.securityContext.runAsGroup }}"
           - name: "FIX_PATHS"
-            value: "/etc/prequel/spool,/etc/prequel/spool_legacy/k8s,/etc/prequel-policy,/etc/prequel/tsdb"
+            value: "/etc/prequel/spool,/etc/prequel/spool_legacy/k8s,/etc/prequel-policy,/etc/prequel/tsdb,/etc/prequel/tsdb_wal"
           volumeMounts:
           - name: spool-volume
             mountPath: /etc/prequel/spool
@@ -89,6 +101,8 @@ spec:
 {{- if .Values.collector.tsdb.enabled }}
           - name: tsdb-volume
             mountPath: "/etc/prequel/tsdb/"
+          - name: tsdb-wal-volume
+            mountPath: "/etc/prequel/tsdb_wal" # Don't use subPath here to allow WAL cleanup on block PVC.  Main container uses subPath.
 {{- end }}
         - name: "cgroupid"
           image: "busybox@sha256:2f590fc602ce325cbff2ccfc39499014d039546dc400ef8bbf5c6ffb860632e7"
@@ -154,6 +168,9 @@ spec:
 {{- if .Values.collector.tsdb.enabled }}
           - mountPath: "/etc/prequel/tsdb/"
             name: tsdb-volume
+          - mountPath: "/etc/prequel/tsdb/wal"
+            name: tsdb-wal-volume
+            subPath: wal
 {{- end }}
           ports:
           - name: health
@@ -239,6 +256,21 @@ spec:
   resources:
     requests:
       storage: {{ .Values.collector.tsdb.tsdbSize }}
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  namespace: {{ .Release.Namespace }}
+  name: tsdb-wal-pv-claim
+spec:
+  accessModes:
+  - ReadWriteOnce
+  {{- if .Values.storageClassName }}
+  storageClassName: {{ .Values.storageClassName }}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.collector.tsdb.walSize }}
 {{- end }}
 ---
 apiVersion: v1

--- a/collector/values.yaml
+++ b/collector/values.yaml
@@ -86,6 +86,7 @@ collector:
   # The event spool size for Prequel events.
   tsdb:
     tsdbSize: 5Gi
+    walSize: 2Gi
     enabled: true # enabled tsdb volume
   eventSpool:
     size: 128Mi


### PR DESCRIPTION
…rove stability.

Prometheus aggressively panics when WAL writes fail, which can happen when the block storage is full. By separating the WAL storage from the block storage, we can prevent WAL write failures from causing the entire Prometheus process to panic. This change involves:

1. Adding a new PersistentVolumeClaim for the WAL storage.
2. Updating the Prometheus configuration to use the new WAL storage path.

goroutine 711 [running]:
github.com/prometheus/prometheus/tsdb.handleChunkWriteError({0x55ddd7bdc5a0, 0xc0019d2d20})         github.com/prometheus/prometheus@v0.309.1/tsdb/head_append.go:2241 +0x5c github.com/prometheus/prometheus/tsdb/chunks.(*ChunkDiskMapper).WriteChunk(0xc00121ca50, 0x63262, 0x19c333bf37b, 0x19c3340875c, {0x55ddd7c0a1e0, 0xc00627c6e0}, 0x0, 0x55ddd7bca898)         github.com/prometheus/prometheus@v0.309.1/tsdb/chunks/head_chunks.go:470 +0x142 github.com/prometheus/prometheus/tsdb.(*memSeries).mmapChunks(0xc004710bb0, 0xc00121ca50)         github.com/prometheus/prometheus@v0.309.1/tsdb/head_append.go:2223 +0xca github.com/prometheus/prometheus/tsdb.(*walSubsetProcessor).processWALSamples(0xc0042fa060, 0xc00036d808, 0xc004300f90, 0xc004300fc0)         github.com/prometheus/prometheus@v0.309.1/tsdb/head_wal.go:650 +0x5f9 github.com/prometheus/prometheus/tsdb.(*Head).loadWAL.func2(0xc0002ff880?)         github.com/prometheus/prometheus@v0.309.1/tsdb/head_wal.go:123 +0x50 created by github.com/prometheus/prometheus/tsdb.(*Head).loadWAL in goroutine 670         github.com/prometheus/prometheus@v0.309.1/tsdb/head_wal.go:122 +0x315
